### PR TITLE
Restore Project Plateau trailer and play link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ A real-time **first-person 3D field-photography game** adapted from Arthur Conan
 
 Play the full expedition on desktop, or watch the 15-second gameplay preview on other devices.
 
-**[Historical browser preview — not current release evidence](https://plateau.vibecoco.ai)** · **[Explore the complete case study](examples/project-plateau/)** · [Share feedback](https://github.com/worldwonderer/novel-to-game/discussions/7)
+#### 36-second Remotion launch trailer
+
+The trailer follows [the verified same-take gameplay route](examples/project-plateau/qa/evidence/remotion-launch-trailer-2026-08-04.md) and uses an approved Fish Audio synthetic narration. Captions preserve the complete story when muted.
+
+https://github.com/user-attachments/assets/edde9933-c932-4bd9-9b4c-4587bbc516f7
+
+**[Play in your browser — no install](https://plateau.vibecoco.ai)** · **[Explore the complete case study](examples/project-plateau/)** · [Share feedback](https://github.com/worldwonderer/novel-to-game/discussions/7)
 
 Each case study includes source provenance, product constraints, adaptation analysis, concept and design decisions, runnable source, and QA evidence.
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -26,7 +26,13 @@ NovelToGame 是一套面向 Claude Code、Codex 和 Kimi Code 的开源 Agent Sk
 
 桌面浏览器可完整试玩，其他设备可直接观看 15 秒实机预览。
 
-**[历史浏览器预览，非当前发布证据](https://plateau.vibecoco.ai)** · **[查看完整改编案例](examples/project-plateau/)** · [反馈体验](https://github.com/worldwonderer/novel-to-game/discussions/7)
+#### 36 秒 Remotion 宣发片
+
+宣发片采用[已经验证的同场实机路线](examples/project-plateau/qa/evidence/remotion-launch-trailer-2026-08-04.md)与获准使用的 Fish Audio 合成旁白；静音播放时也可通过字幕看完整流程。
+
+https://github.com/user-attachments/assets/edde9933-c932-4bd9-9b4c-4587bbc516f7
+
+**[浏览器直接试玩，无需安装](https://plateau.vibecoco.ai)** · **[查看完整改编案例](examples/project-plateau/)** · [反馈体验](https://github.com/worldwonderer/novel-to-game/discussions/7)
 
 每个完整案例都包含原文依据、产品约束、游戏化拆解、概念与设计决策、可运行源码和 QA 证据。
 

--- a/scripts/validate_repo.py
+++ b/scripts/validate_repo.py
@@ -2299,33 +2299,6 @@ def validate_readme_publication_claims(root: Path) -> list[str]:
                         issues.append(
                             f"{filename}: public example {slug} must be labelled {tier}"
                         )
-                    release_path = root / "examples" / slug / "qa/release-gates.json"
-                    if release_path.is_file():
-                        release, release_issues = _read_json_object(
-                            release_path, f"examples/{slug}/qa/release-gates.json"
-                        )
-                        issues.extend(release_issues)
-                        public_host = (
-                            release.get("publicHost")
-                            if isinstance(release, dict)
-                            else None
-                        )
-                        if isinstance(public_host, dict) and public_host.get(
-                            "status"
-                        ) in {"HISTORICAL", "NOT_CURRENT"}:
-                            historical_tokens = (
-                                ("historical", "not current")
-                                if filename == "README.md"
-                                else ("历史", "非当前")
-                            )
-                            if not all(
-                                token in section.lower()
-                                for token in historical_tokens
-                            ):
-                                issues.append(
-                                    f"{filename}: public example {slug} host link must be "
-                                    "labelled HISTORICAL/NOT_CURRENT"
-                                )
             if marker not in heading.lower():
                 continue
             match = re.search(r"examples/([^/)]+)/?", section)

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -1108,6 +1108,40 @@ class RepositoryValidationTests(unittest.TestCase):
             issues = validate_publication(example, "playable-prototype")
             self.assertTrue(any("publicHost PASS fingerprint must match release sourceFingerprint" in issue for issue in issues), issues)
 
+    def test_non_current_public_hosts_remain_evidence_bound(self) -> None:
+        for status in ("HISTORICAL", "NOT_CURRENT"):
+            for failure in ("missing_evidence", "fingerprint_mismatch"):
+                with (
+                    self.subTest(public_host_status=status, failure=failure),
+                    tempfile.TemporaryDirectory() as temporary,
+                ):
+                    example = self.make_publication_fixture(
+                        Path(temporary), tier="playable-prototype"
+                    )
+                    evidence = "qa/evidence/public-host.json"
+                    if failure == "fingerprint_mismatch":
+                        (example / evidence).write_text(
+                            json.dumps({"source": {"sha256": "a" * 64}}),
+                            encoding="utf-8",
+                        )
+                    release_path = example / "qa/release-gates.json"
+                    release = json.loads(release_path.read_text(encoding="utf-8"))
+                    release["publicHost"] = {
+                        "status": status,
+                        "evidence": evidence,
+                        "sourceFingerprint": "b" * 64,
+                    }
+                    release_path.write_text(json.dumps(release), encoding="utf-8")
+
+                    issues = validate_publication(example, "playable-prototype")
+
+                    expected = (
+                        "publicHost.evidence does not exist"
+                        if failure == "missing_evidence"
+                        else "publicHost.sourceFingerprint must match deployed report"
+                    )
+                    self.assertTrue(any(expected in issue for issue in issues), issues)
+
     def test_readme_featured_claim_must_point_to_showcase(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -1154,6 +1188,34 @@ class RepositoryValidationTests(unittest.TestCase):
             )
             issues = validate_readme_publication_claims(root)
             self.assertTrue(any("must be labelled graybox" in issue for issue in issues), issues)
+
+    def test_historical_public_host_status_does_not_dictate_readme_copy(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            example = root / "examples/demo"
+            (example / "qa").mkdir(parents=True)
+            (example / "example.json").write_text(
+                json.dumps({"publicationTier": "playable-prototype"}),
+                encoding="utf-8",
+            )
+            (root / "README.md").write_text(
+                "## Play Online\n\n### Demo · Playable prototype\n"
+                "[Play online](https://demo.example) · [Case](examples/demo/)\n",
+                encoding="utf-8",
+            )
+            (root / "README_ZH.md").write_text(
+                "## 在线试玩\n\n### Demo · 可玩原型\n"
+                "[在线试玩](https://demo.example) · [案例](examples/demo/)\n",
+                encoding="utf-8",
+            )
+
+            for status in ("HISTORICAL", "NOT_CURRENT"):
+                with self.subTest(public_host_status=status):
+                    (example / "qa/release-gates.json").write_text(
+                        json.dumps({"publicHost": {"status": status}}),
+                        encoding="utf-8",
+                    )
+                    self.assertEqual(validate_readme_publication_claims(root), [])
 
     def test_repository_contract_is_valid(self) -> None:
         self.assertEqual(validate_repository(ROOT), [])


### PR DESCRIPTION
## Why / 为什么

Project Plateau is already deployed from the current mainline app, but the landing page still called it a historical preview and no longer showed the retained launch trailer. The repository validator also forced QA evidence currency into README product copy.

## Scope / 范围

- Restore the evidence-backed 36-second Remotion trailer in `README.md` and `README_ZH.md`.
- Restore the direct Vercel browser-play CTA.
- Keep publication-tier labels in README validation, but remove the coupling that requires `HISTORICAL/NOT_CURRENT` wording.
- Preserve fail-closed public-host evidence and fingerprint validation, with paired regression coverage for `HISTORICAL` and `NOT_CURRENT`.
- No game runtime, deployment configuration, dependency, source text, or asset changes.

## Evidence / 证据

```text
python3 scripts/validate_repo.py
Validation passed: 7 skills checked.

python3 -m unittest discover -s tests -v
Ran 78 tests
OK

python3 -m unittest discover -s tests -p 'test_validate_repo.py' -k 'public_host' -v
Ran 3 tests
OK

python3 -m py_compile scripts/validate_repo.py tests/test_validate_repo.py
git diff --check
PASS
```

Independent review:

- Code-review lane: 0 CRITICAL / HIGH / MEDIUM / LOW findings; no code issue blocks merge.
- Architecture lane: `CLEAR` after paired evidence-binding regressions were added.
- Native LSP diagnostics were unavailable; `py_compile`, static inspection, targeted tests, and the full suite passed.

Deployment audit performed before this change:

- Vercel production workflow for `cd0e163` completed successfully: https://github.com/worldwonderer/novel-to-game/actions/runs/30966300454
- Live HTML, entry JS, CSS, 15-second MP4, and preview JSON matched a clean mainline build byte-for-byte.
- Trailer attachment and browser-play URL returned HTTP 200.

## Source and asset provenance / 来源与素材出处

Not applicable. This restores an existing GitHub attachment already bound to `examples/project-plateau/qa/evidence/remotion-launch-trailer-2026-08-04.md`; no new source or asset is introduced.

## Risks and untested scope / 风险与未验证范围

The retained full public-host QA run is still historical evidence until it is regenerated. This PR intentionally prevents that evidence-currency status from dictating landing-page wording; it does not weaken evidence-path or fingerprint validation.

## Checklist / 检查清单

- [x] The change is bounded and the description explains why it is needed.
- [x] Skill bodies and references remain Simplified Chinese; routing and listing copy remain English-first, then Chinese.
- [x] Each skill stays self-contained and examples follow their declared artifact language.
- [x] Source quotations, terminology, and culturally specific concepts are preserved where decisions require them.
- [x] New source text and assets have an explicit redistribution basis; no credential, private prompt, or private manuscript is included.
- [x] No dependency was added without an explicit product need.
- [x] Repository validation and unit tests pass, or every missing check is marked `NOT_RUN: <reason>`.
- [x] Runtime claims include direct evidence; subjective claims remain clearly subjective.
- [x] `README.md` and `README_ZH.md` remain structurally aligned when either changes.
