### PR TITLE
Fix Project Plateau live exposure settlement

### DIFF
--- a/examples/project-plateau/build/BUILD_BRIEF.md
+++ b/examples/project-plateau/build/BUILD_BRIEF.md
@@ -36,12 +36,14 @@ replace the non-lethal scout fantasy with combat, crafting, a cinematic or a das
 1. One continuous Fort → brook → observation fork → glade → two return routes → Fort
    space with readable landmarks, cover and collision.
 2. Four physical plates whose two-axis live camera direction, exposure stability, captured
-   obstruction, scale and distinct behaviour determine the visible record; empty, edge, clear
-   and smeared frames remain legible while recording stays live and exposed. Crouching before
-   the shutter braces the camera without removing exposure risk.
+   obstruction, scale and distinct behaviour are checked throughout the exposure; empty, edge,
+   clear and smeared frames remain legible while recording stays live and exposed. Plate meaning
+   and its preview commit together at the final boundary. Crouching before the shutter braces the
+   camera without removing exposure risk, while a continuously framed moving wing may be tracked.
 3. Readable iguanodon routine/young-play/branch-pull/alarm windows and pterodactyl
    distant/watch/search/attack states. Family behaviours and the optional committed-dive plate
-   require distinct timing and framing, not repeated shutters in one zone.
+   require distinct timing and framing; every repeated two-cue composition, including basalt and
+   creek scale, degrades rather than letting repeated shutters replace observation.
 4. Canopy cover, one recoverable contact, two rifle cartridges and the downstream cost
    of firing.
 5. A 180-second light budget, four alive result bands, deadline/contact failure and one

--- a/examples/project-plateau/build/app/src/field-photography.js
+++ b/examples/project-plateau/build/app/src/field-photography.js
@@ -139,8 +139,9 @@ export function createPendingExposure(state, plateIndex, durationSeconds) {
     driftLimit: MAX_STEADY_DRIFT_RADIANS * (braced ? 1.8 : 1),
     initialSubject: frame.subject,
     initialBehavior: frame.behavior,
+    maxExposureRisk: frame.exposure,
     continuousSubject: frame.subject !== null,
-    continuousBehavior: true,
+    continuousBehavior: frame.behavior !== null,
     worstComposition: frame.composition,
   };
 }
@@ -162,6 +163,10 @@ export function updatePendingExposure(pending, liveFrame, heading, pitch, deltaS
     driftLimit: pending.driftLimit,
     initialSubject: pending.initialSubject,
     initialBehavior: pending.initialBehavior,
+    maxExposureRisk: Math.max(
+      pending.maxExposureRisk ?? pending.exposure ?? 0,
+      liveFrame.exposure ?? 0,
+    ),
     continuousSubject: pending.continuousSubject
       && liveFrame.subject !== null
       && liveFrame.subject === pending.initialSubject,
@@ -198,7 +203,11 @@ export function proofForExposure(pending) {
       label: 'FORM — the living subject crossed the plate edge during exposure.',
       composition: 'edge', behavior: null,
     };
-  } else if (!pending.continuousBehavior && pending.initialBehavior && proof.points > 1) {
+  } else if (proof.behavior && (
+    !pending.initialBehavior
+    || !pending.continuousBehavior
+    || proof.behavior !== pending.initialBehavior
+  ) && proof.points > 1) {
     proof = {
       ...proof, key: 'behavior-lost', points: 1,
       label: 'FORM — the behavior did not hold through the exposure.', behavior: null,

--- a/examples/project-plateau/build/app/src/field-photography.js
+++ b/examples/project-plateau/build/app/src/field-photography.js
@@ -8,7 +8,7 @@ const EDGE_HEADING_RADIANS = 0.68;
 const CLEAR_FAMILY_PITCH_RADIANS = 0.38;
 const EDGE_FAMILY_PITCH_RADIANS = 0.75;
 const DIVE_PITCH_RADIANS = Object.freeze({ min: 0.16, max: 0.68, edgeMin: 0.06, edgeMax: 0.86 });
-const DIVE_SECONDS = Object.freeze({ min: 0.5, max: 2.24 });
+const DIVE_SECONDS = Object.freeze({ min: 0.5, max: 3 });
 
 const familyCenter = centerOf(FAMILY_LAYOUT);
 const youngPlayCenter = centerOf(

--- a/examples/project-plateau/build/app/src/field-photography.js
+++ b/examples/project-plateau/build/app/src/field-photography.js
@@ -54,7 +54,21 @@ function familyCompositionForTarget(state, target) {
 }
 
 function hasCaptured(state, frameKey) {
-  return state.plates.some((plate) => plate.status === 'exposed' && plate.frameKey === frameKey);
+  return state.plates.some(
+    (plate) => plate.status === 'exposed'
+      && (plate.frameKey === frameKey || plate.sourceFrameKey === frameKey),
+  );
+}
+
+function downgradeRepeatedHighValueFrame(state, frame) {
+  if (frame.points < 2 || !hasCaptured(state, frame.key)) return frame;
+  return {
+    ...frame,
+    key: `${frame.key}-repeat`,
+    points: 1,
+    label: 'REPEAT — this high-value composition is already in the case.',
+    behavior: null,
+  };
 }
 
 function pterodactylFrameForState(state) {
@@ -100,6 +114,97 @@ export function cameraDriftFromExposure(pending, heading, pitch) {
   const headingDrift = wrapAngle((heading ?? 0) - (pending.startHeading ?? 0));
   const pitchDrift = (pitch ?? 0) - (pending.startPitch ?? 0);
   return Math.hypot(headingDrift, pitchDrift);
+}
+
+const COMPOSITION_QUALITY = Object.freeze({ empty: 0, unread: 0, edge: 1, clear: 2 });
+
+function worseComposition(first, second) {
+  return (COMPOSITION_QUALITY[second] ?? 0) < (COMPOSITION_QUALITY[first] ?? 0)
+    ? second
+    : first;
+}
+
+export function createPendingExposure(state, plateIndex, durationSeconds) {
+  const frame = frameForState(state);
+  const braced = state.stance === 'crouch' || state.inCover;
+  return {
+    ...frame,
+    plateIndex,
+    remainingSeconds: durationSeconds,
+    zone: state.zone,
+    startHeading: state.heading,
+    startPitch: state.pitch,
+    maxCameraDrift: 0,
+    braced,
+    driftLimit: MAX_STEADY_DRIFT_RADIANS * (braced ? 1.8 : 1),
+    initialSubject: frame.subject,
+    initialBehavior: frame.behavior,
+    continuousSubject: frame.subject !== null,
+    continuousBehavior: true,
+    worstComposition: frame.composition,
+  };
+}
+
+export function updatePendingExposure(pending, liveFrame, heading, pitch, deltaSeconds) {
+  return {
+    ...pending,
+    ...liveFrame,
+    plateIndex: pending.plateIndex,
+    zone: pending.zone,
+    remainingSeconds: Math.max(0, pending.remainingSeconds - deltaSeconds),
+    startHeading: pending.startHeading,
+    startPitch: pending.startPitch,
+    maxCameraDrift: Math.max(
+      pending.maxCameraDrift ?? 0,
+      cameraDriftFromExposure(pending, heading, pitch),
+    ),
+    braced: pending.braced,
+    driftLimit: pending.driftLimit,
+    initialSubject: pending.initialSubject,
+    initialBehavior: pending.initialBehavior,
+    continuousSubject: pending.continuousSubject
+      && liveFrame.subject !== null
+      && liveFrame.subject === pending.initialSubject,
+    continuousBehavior: pending.continuousBehavior
+      && liveFrame.behavior === pending.initialBehavior,
+    worstComposition: worseComposition(pending.worstComposition, liveFrame.composition),
+  };
+}
+
+export function proofForExposure(pending) {
+  const trackedMovingSubject = pending.initialSubject === 'pterodactyl'
+    && pending.continuousSubject
+    && pending.worstComposition !== 'empty';
+  const shaken = !trackedMovingSubject
+    && pending.maxCameraDrift > (pending.driftLimit ?? MAX_STEADY_DRIFT_RADIANS);
+  let proof = shaken ? {
+    key: 'shaken-frame',
+    points: pending.points > 0 ? 1 : 0,
+    label: 'SMEARED — camera drift erased the decisive detail.',
+    composition: 'shaken',
+    subject: pending.subject,
+    behavior: null,
+    stability: 'shaken',
+  } : { ...pending, stability: 'steady' };
+  if (!pending.continuousSubject || pending.worstComposition === 'empty') {
+    proof = {
+      ...proof, key: 'empty-subject', points: 0,
+      label: 'EMPTY — the living subject left the plate during exposure.',
+      composition: 'empty', subject: null, behavior: null,
+    };
+  } else if (pending.worstComposition === 'edge' && proof.points > 1) {
+    proof = {
+      ...proof, key: 'family-edge', points: 1,
+      label: 'FORM — the living subject crossed the plate edge during exposure.',
+      composition: 'edge', behavior: null,
+    };
+  } else if (!pending.continuousBehavior && pending.initialBehavior && proof.points > 1) {
+    proof = {
+      ...proof, key: 'behavior-lost', points: 1,
+      label: 'FORM — the behavior did not hold through the exposure.', behavior: null,
+    };
+  }
+  return proof;
 }
 
 function emptySubjectFrame(familyMoment) {
@@ -206,6 +311,14 @@ function familyFrameForState(state, baseFrame) {
   };
 }
 
+function orientedStaticFrame(state, baseFrame) {
+  const familyMoment = familyMomentForState(state);
+  const composition = familyCompositionForTarget(state, familyTargetForMoment(familyMoment));
+  if (composition === 'empty') return emptySubjectFrame(familyMoment);
+  if (composition === 'edge') return edgeSubjectFrame(familyMoment);
+  return { ...baseFrame, familyMoment };
+}
+
 export function frameForState(state) {
   const pterodactylFrame = pterodactylFrameForState(state);
   if (pterodactylFrame) return pterodactylFrame;
@@ -247,6 +360,9 @@ export function frameForState(state) {
   };
   const frame = frames[state.zone];
   if (!frame) return frames.fort;
-  if (state.zone === 'brook-blind' || state.zone === 'fort') return { ...frame };
-  return familyFrameForState(state, frame);
+  if (state.zone === 'fort') return { ...frame };
+  const composed = state.zone === 'brook-blind'
+    ? orientedStaticFrame(state, frame)
+    : familyFrameForState(state, frame);
+  return downgradeRepeatedHighValueFrame(state, composed);
 }

--- a/examples/project-plateau/build/app/src/main.js
+++ b/examples/project-plateau/build/app/src/main.js
@@ -449,10 +449,10 @@ function updateFieldHud(now) {
     && previewPlate?.status === 'exposed';
   platePreview.hidden = !showPreview;
   if (showPreview) {
-    const { plateIndex, key } = player.lastProofEvent;
+    const { plateIndex, frameKey } = player.lastProofEvent;
     previewNumber.textContent = ROMAN_PLATES[plateIndex];
     previewCopy.textContent = player.lastProofEvent.label;
-    previewImage.dataset.frame = key;
+    previewImage.dataset.frame = frameKey;
     applyPlateImage(previewImage, plateImages[plateIndex]);
   }
 
@@ -716,6 +716,7 @@ function update(deltaSeconds, now) {
       if (player.familyMoment === 'glade-branch-pull') emitCue('family-branch', 2600);
     }
     if ((player.lastProofEvent?.plateIndex ?? -1) !== previousProofPlate) {
+      queuePlateCapture(player.lastProofEvent.plateIndex);
       emitCue('plate-slide');
     }
     if (player.returnRoute !== previousRoute && player.returnRoute === 'covered') emitCue('cover');
@@ -960,7 +961,6 @@ document.addEventListener('mousedown', (event) => {
     const hadPendingExposure = Boolean(player.pendingExposure);
     player = startExposure(player);
     if (!hadPendingExposure && player.pendingExposure) {
-      queuePlateCapture(player.pendingExposure.plateIndex);
       emitCue('shutter');
     }
   }

--- a/examples/project-plateau/build/app/src/simulation.js
+++ b/examples/project-plateau/build/app/src/simulation.js
@@ -2,9 +2,11 @@ import { planarAxesForHeading } from './controller.js';
 import {
   FAMILY_BEHAVIOR_CYCLE_SECONDS,
   MAX_STEADY_DRIFT_RADIANS,
-  cameraDriftFromExposure,
+  createPendingExposure,
   familyMomentForState,
   frameForState,
+  proofForExposure,
+  updatePendingExposure,
 } from './field-photography.js';
 import { integrateMovement } from './simulation-movement.js';
 export {
@@ -261,17 +263,7 @@ export function startExposure(state) {
   const plateIndex = state.plates.findIndex((plate) => plate.status === 'unexposed');
   if (plateIndex < 0) return copyState(state, { cameraRaised: false, lastEvent: 'camera:no-plates' });
   return copyState(state, {
-    pendingExposure: {
-      ...frameForState(state),
-      plateIndex,
-      remainingSeconds: EXPOSURE_SECONDS,
-      zone: state.zone,
-      startHeading: state.heading,
-      startPitch: state.pitch,
-      maxCameraDrift: 0,
-      braced: state.stance === 'crouch' || state.inCover,
-      driftLimit: MAX_STEADY_DRIFT_RADIANS * ((state.stance === 'crouch' || state.inCover) ? 1.8 : 1),
-    },
+    pendingExposure: createPendingExposure(state, plateIndex, EXPOSURE_SECONDS),
     previewSeconds: 0,
     velocity: { x: 0, z: 0 },
     rifleRaised: false,
@@ -559,18 +551,7 @@ function updateThreatState(state, zone, stance, deltaSeconds, travelled) {
 }
 
 function finalizeExposure(state, pending, threat) {
-  const shaken = pending.maxCameraDrift > (pending.driftLimit ?? MAX_STEADY_DRIFT_RADIANS);
-  const proof = shaken
-    ? {
-      key: 'shaken-frame',
-      points: pending.points > 0 ? 1 : 0,
-      label: 'SMEARED — camera drift erased the decisive detail.',
-      composition: 'shaken',
-      subject: pending.subject,
-      behavior: null,
-      stability: 'shaken',
-    }
-    : { ...pending, stability: 'steady' };
+  const proof = proofForExposure(pending);
   const plates = state.plates.map(clonePlate);
   plates[pending.plateIndex] = {
     ...plates[pending.plateIndex],
@@ -667,15 +648,21 @@ export function stepPlayer(state, input = {}, rawDeltaSeconds = 0) {
     familyBehaviorSeconds,
   });
   const zoneHistory = zone === state.zone ? [...state.zoneHistory] : [...state.zoneHistory, zone];
+  const exposureFrame = state.pendingExposure
+    ? frameForState({
+      ...state,
+      heading,
+      pitch,
+      zone,
+      reachedGlade,
+      familyBehaviorSeconds,
+      familyMoment,
+      threatAwareness: threat.awareness,
+      threatState: threat.threatState,
+    })
+    : null;
   const pendingExposure = state.pendingExposure
-    ? {
-      ...state.pendingExposure,
-      remainingSeconds: Math.max(0, state.pendingExposure.remainingSeconds - deltaSeconds),
-      maxCameraDrift: Math.max(
-        state.pendingExposure.maxCameraDrift ?? 0,
-        cameraDriftFromExposure(state.pendingExposure, heading, pitch),
-      ),
-    }
+    ? updatePendingExposure(state.pendingExposure, exposureFrame, heading, pitch, deltaSeconds)
     : null;
   let next = copyState(state, {
     position: clonePosition(resolved.position),

--- a/examples/project-plateau/build/app/src/simulation.js
+++ b/examples/project-plateau/build/app/src/simulation.js
@@ -552,6 +552,7 @@ function updateThreatState(state, zone, stance, deltaSeconds, travelled) {
 
 function finalizeExposure(state, pending, threat) {
   const proof = proofForExposure(pending);
+  const exposureRisk = pending.maxExposureRisk ?? pending.exposure;
   const plates = state.plates.map(clonePlate);
   plates[pending.plateIndex] = {
     ...plates[pending.plateIndex],
@@ -565,7 +566,7 @@ function finalizeExposure(state, pending, threat) {
     subject: proof.subject,
     behavior: proof.behavior,
   };
-  const awareness = Math.min(3, threat.awareness + pending.exposure);
+  const awareness = Math.min(3, threat.awareness + exposureRisk);
   return {
     plates,
     pendingExposure: null,
@@ -573,7 +574,7 @@ function finalizeExposure(state, pending, threat) {
     cameraRaised: false,
     threatAwareness: awareness,
     threatState: THREAT_STATES[awareness],
-    lastThreatEvent: pending.exposure > 0 ? `plate-exposure:+${pending.exposure}` : threat.event,
+    lastThreatEvent: exposureRisk > 0 ? `plate-exposure:+${exposureRisk}` : threat.event,
     lastProofEvent: {
       plateIndex: pending.plateIndex,
       frameKey: proof.key,

--- a/examples/project-plateau/build/app/test/qa_complete_run.py
+++ b/examples/project-plateau/build/app/test/qa_complete_run.py
@@ -162,9 +162,18 @@ def run() -> dict[str, Any]:
                 page.keyboard.up("KeyC")
             input_trace.append(f"hold KeyC under cover: {purpose}")
 
-        def wait_for_family_moment(moment: str) -> None:
+        def wait_for_family_moment(moment: str, window_end: float) -> None:
+            # Do not accept a matching label at the tail of its window: the
+            # authoritative path must leave the full two-second exposure plus
+            # a small input/render margin before the behavior changes.
+            latest_start = window_end - 2.25
             page.wait_for_function(
-                f"window.__projectPlateau.snapshot().player.familyMoment === '{moment}'",
+                """([moment, latestStart]) => {
+                    const player = window.__projectPlateau.snapshot().player;
+                    return player.familyMoment === moment
+                        && player.familyBehaviorSeconds <= latestStart;
+                }""",
+                arg=[moment, latest_start],
                 timeout=10000,
             )
 
@@ -200,7 +209,7 @@ def run() -> dict[str, Any]:
             "reach the glade",
         )
         page.keyboard.press("KeyE")
-        wait_for_family_moment("glade-young-play")
+        wait_for_family_moment("glade-young-play", 4.6)
         expose_plate(2, "record young at play")
         move_until(
             "KeyS",
@@ -213,7 +222,7 @@ def run() -> dict[str, Any]:
             "window.__projectPlateau.snapshot().player.position.z <= 2",
             "return for the second behavior plate",
         )
-        wait_for_family_moment("glade-branch-pull")
+        wait_for_family_moment("glade-branch-pull", 9.0)
         expose_plate(3, "record branch pulling")
         move_until(
             "KeyS",

--- a/examples/project-plateau/build/app/test/simulation.test.js
+++ b/examples/project-plateau/build/app/test/simulation.test.js
@@ -266,6 +266,9 @@ test('examining the brook makes context eligible without awarding evidence', () 
   assert.equal(player.lastObservation, 'Three toes. Fresh. The brook runs back to camp.');
   assert.equal(player.plates.reduce((total, plate) => total + plate.points, 0), 0);
   assert.equal(frameForState(player).points, 1);
+
+  assert.equal(frameForState({ ...player, heading: Math.PI }).key, 'empty-subject');
+  assert.equal(frameForState({ ...player, pitch: -1 }).key, 'empty-subject');
 });
 
 test('the live camera direction distinguishes a clear subject, an edge frame and empty forest', () => {
@@ -333,6 +336,73 @@ test('a committed pterodactyl dive is a risky alternate evidence subject', () =>
   const repeated = frameForState(player);
   assert.equal(repeated.key, 'pterodactyl-repeat');
   assert.equal(repeated.points, 1);
+});
+
+test('a tracked pterodactyl stays sharp while subject loss during exposure spends an empty plate', () => {
+  const diveState = () => {
+    const player = createPlayerState();
+    player.position = { x: 8, z: 18 };
+    player.lastStablePosition = { ...player.position };
+    player.zone = 'basalt-shelf';
+    player.heading = 0.28;
+    player.pitch = 0.32;
+    player.threatAwareness = 3;
+    player.threatState = 'attack';
+    player.attackSeconds = 0.7;
+    return player;
+  };
+
+  let tracked = startExposure(setCameraRaised(diveState(), true));
+  tracked = stepPlayer(tracked, { heading: 0.38, pitch: 0.32 }, 1);
+  assert.ok(tracked.pendingExposure.maxCameraDrift > MAX_STEADY_DRIFT_RADIANS);
+  tracked = stepPlayer(tracked, { heading: 0.38, pitch: 0.32 }, 1);
+  assert.equal(tracked.plates[0].frameKey, 'pterodactyl-dive');
+  assert.equal(tracked.plates[0].stability, 'steady');
+  assert.equal(tracked.plates[0].points, 2);
+
+  let lost = startExposure(setCameraRaised(diveState(), true));
+  lost = stepPlayer(lost, { heading: 0.28, pitch: 0 }, 1);
+  lost = stepPlayer(lost, { heading: 0.28, pitch: 0.32 }, 1);
+  assert.equal(lost.plates[0].frameKey, 'empty-subject');
+  assert.equal(lost.plates[0].points, 0);
+  assert.match(lost.plates[0].label, /left the plate/i);
+});
+
+test('behavior must remain valid through the exposure rather than only at shutter start', () => {
+  let player = createPlayerState();
+  player.position = { x: 0, z: -8 };
+  player.lastStablePosition = { ...player.position };
+  player = stepPlayer(player, {}, 0.1);
+  player = examine(player);
+  player.familyBehaviorSeconds = 4.4;
+  player.familyMoment = familyMomentForState(player);
+  assert.equal(frameForState(player).key, 'glade-young-play');
+
+  player = startExposure(setCameraRaised(player, true));
+  player = stepPlayer(player, {}, 1);
+  player = stepPlayer(player, {}, 1);
+  assert.equal(player.plates[0].points, 1);
+  assert.equal(player.plates[0].behavior, null);
+  assert.notEqual(player.plates[0].sourceFrameKey, 'glade-young-play');
+});
+
+test('repeated two-cue basalt and creek compositions degrade to one cue', () => {
+  let basalt = createPlayerState();
+  basalt.position = { x: 8, z: 18 };
+  basalt.lastStablePosition = { ...basalt.position };
+  basalt = stepPlayer(basalt, {}, 0.1);
+  basalt.plates[0] = {
+    ...basalt.plates[0], status: 'exposed', points: 2, frameKey: 'basalt-scale',
+  };
+  assert.equal(frameForState(basalt).key, 'basalt-scale-repeat');
+  assert.equal(frameForState(basalt).points, 1);
+
+  let creek = { ...basalt, reachedGlade: true, zone: 'exposed-creek' };
+  creek.plates = creek.plates.map((plate, index) => index === 0
+    ? { ...plate, frameKey: 'creek-scale', sourceFrameKey: 'creek-scale' }
+    : plate);
+  assert.equal(frameForState(creek).key, 'creek-scale-repeat');
+  assert.equal(frameForState(creek).points, 1);
 });
 
 test('camera drift during a live exposure smears high-value evidence', () => {

--- a/examples/project-plateau/build/app/test/simulation.test.js
+++ b/examples/project-plateau/build/app/test/simulation.test.js
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  createPendingExposure,
+  proofForExposure,
+  updatePendingExposure,
+} from '../src/field-photography.js';
+import {
   CONTACT_SECONDS,
   FAMILY_BEHAVIOR_CYCLE_SECONDS,
   EXPOSURE_SECONDS,
@@ -352,13 +357,45 @@ test('a tracked pterodactyl stays sharp while subject loss during exposure spend
     return player;
   };
 
+  const browserFrameSeconds = 1 / 60;
   let tracked = startExposure(setCameraRaised(diveState(), true));
-  tracked = stepPlayer(tracked, { heading: 0.38, pitch: 0.32 }, 1);
-  assert.ok(tracked.pendingExposure.maxCameraDrift > MAX_STEADY_DRIFT_RADIANS);
-  tracked = stepPlayer(tracked, { heading: 0.38, pitch: 0.32 }, 1);
+  let trackedMaxDrift = 0;
+  for (let frame = 0; frame < 180 && tracked.pendingExposure; frame += 1) {
+    tracked = stepPlayer(
+      tracked,
+      { heading: 0.38, pitch: 0.32 },
+      browserFrameSeconds,
+    );
+    trackedMaxDrift = Math.max(
+      trackedMaxDrift,
+      tracked.pendingExposure?.maxCameraDrift ?? 0,
+    );
+  }
+  assert.equal(tracked.pendingExposure, null);
+  assert.ok(trackedMaxDrift > MAX_STEADY_DRIFT_RADIANS);
   assert.equal(tracked.plates[0].frameKey, 'pterodactyl-dive');
   assert.equal(tracked.plates[0].stability, 'steady');
   assert.equal(tracked.plates[0].points, 2);
+
+  const lateDive = { ...diveState(), attackSeconds: 1.1 };
+  let sampledAttackSeconds = lateDive.attackSeconds;
+  let crossedWindow = createPendingExposure(lateDive, 0, EXPOSURE_SECONDS);
+  for (let frame = 0; frame < 180 && crossedWindow.remainingSeconds > 0; frame += 1) {
+    sampledAttackSeconds += browserFrameSeconds;
+    const liveState = { ...lateDive, attackSeconds: sampledAttackSeconds };
+    crossedWindow = updatePendingExposure(
+      crossedWindow,
+      frameForState(liveState),
+      liveState.heading,
+      liveState.pitch,
+      browserFrameSeconds,
+    );
+  }
+  assert.equal(crossedWindow.remainingSeconds, 0);
+  const lateProof = proofForExposure(crossedWindow);
+  assert.equal(lateProof.points, 0);
+  assert.equal(lateProof.behavior, null);
+  assert.match(lateProof.label, /left the plate/i);
 
   let lost = startExposure(setCameraRaised(diveState(), true));
   lost = stepPlayer(lost, { heading: 0.28, pitch: 0 }, 1);

--- a/examples/project-plateau/build/app/test/simulation.test.js
+++ b/examples/project-plateau/build/app/test/simulation.test.js
@@ -423,6 +423,40 @@ test('behavior must remain valid through the exposure rather than only at shutte
   assert.notEqual(player.plates[0].sourceFrameKey, 'glade-young-play');
 });
 
+test('behavior must already be present at shutter start to earn behavior evidence', () => {
+  let player = createPlayerState();
+  player.position = { x: 0, z: -8 };
+  player.lastStablePosition = { ...player.position };
+  player = stepPlayer(player, {}, 0.1);
+  player = examine(player);
+  player.familyBehaviorSeconds = 0.5;
+  assert.equal(frameForState(player).key, 'glade-form');
+
+  player = startExposure(setCameraRaised(player, true));
+  for (let frame = 0; frame < 4; frame += 1) player = stepPlayer(player, {}, 0.5);
+
+  assert.equal(player.plates[0].points, 1);
+  assert.equal(player.plates[0].behavior, null);
+  assert.equal(player.plates[0].frameKey, 'behavior-lost');
+});
+
+test('exposure threat uses the riskiest sampled frame even when the final plate is empty', () => {
+  let player = createPlayerState();
+  player.position = { x: 8, z: 18 };
+  player.lastStablePosition = { ...player.position };
+  player = stepPlayer(player, {}, 0.1);
+  assert.equal(player.threatAwareness, 1);
+
+  player = startExposure(setCameraRaised(player, true));
+  player = stepPlayer(player, {}, 1);
+  player = stepPlayer(player, {}, 0.9);
+  player = stepPlayer(player, { pitch: 1 }, 0.1);
+
+  assert.equal(player.plates[0].frameKey, 'empty-subject');
+  assert.equal(player.threatAwareness, 3);
+  assert.equal(player.lastThreatEvent, 'plate-exposure:+2');
+});
+
 test('repeated two-cue basalt and creek compositions degrade to one cue', () => {
   let basalt = createPlayerState();
   basalt.position = { x: 8, z: 18 };

--- a/examples/project-plateau/design/GAME_DESIGN.md
+++ b/examples/project-plateau/design/GAME_DESIGN.md
@@ -30,9 +30,11 @@ Three pillars govern every system:
 The photography precedent is behaviour-led field observation rather than a passive photo
 mode: behaviour rarity, composition and steadiness are separate reads, while the source novel
 makes the physical plate and its safe return part of the same decision. The prototype therefore
-rejects a photograph when the living subject is outside the actual view, smears a high-value
-exposure if the scout pans during the two-second commitment and rewards distinct behaviour
-rather than repeated zone visits.
+checks subject, behaviour and both composition axes throughout the two-second exposure, settles
+the plate and its rendered preview at the same final boundary, and rewards distinct observations
+rather than repeated high-value compositions in one zone. A deliberate pan still smears a static
+subject, while a continuously framed moving wing can be tracked without treating that pan alone
+as camera shake.
 
 ## Core loop and action arc
 
@@ -56,10 +58,13 @@ releasing the shutter spends one plate after a live two-second commitment. A pla
 cues for subject visibility, scale, ecological context or a distinct behaviour, up to eight
 total authored points across the run. The camera reads both axes of the scout's live view:
 turning or pitching away records an empty plate, an edge frame records form only, and a clear
-view can record context or behaviour. Panning during the exposure smears decisive detail down
-to at most one cue and removes behaviour proof; crouching before the shutter braces the camera
-and widens the stable tolerance. Repeating the same behaviour cannot replace a new angle. The
-preview shows the actual composition and named evidence captured, not an abstract quality bar.
+view can record context or behaviour. Losing the subject, behaviour window or clear composition
+during the exposure lowers the final plate even if the shutter began clean. Panning across a
+static subject smears decisive detail down to at most one cue and removes behaviour proof;
+crouching before the shutter braces the camera and widens the stable tolerance. A continuously
+framed pterodactyl can instead be tracked through its motion. Repeating any two-cue composition,
+including basalt or creek scale, cannot replace a new angle. The preview shows the final-boundary
+composition and named evidence captured, not an earlier shutter snapshot or abstract quality bar.
 
 ### Wildlife awareness
 


### PR DESCRIPTION
## Summary
- validate subject, behavior, and composition throughout each two-second exposure
- allow continuously framed pterodactyl tracking without absolute-pan smear
- commit plate semantics and rendered preview on the same final frame
- downgrade repeated two-cue compositions, including basalt and creek, and enforce brook orientation

## Verification
- `npm test` (199 tests)
- `npm run build`
- `python3 scripts/validate_repo.py`
- `python3 -m unittest discover -s tests -v` (46 tests)