### PR TITLE
docs: migrate repository namespace to zenstory-ai

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "novel-to-game-skills",
   "owner": {
-    "name": "worldwonderer"
+    "name": "zenstory-ai"
   },
   "metadata": {
     "description": "Turn any novel into a source-grounded, fully playable game through adaptation planning, target-platform build, and evidence-based QA. 通过改编策划、目标平台构建和证据化质量验证，把小说转成可完整游玩的游戏。",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "worldwonderer",
     "url": "https://github.com/worldwonderer"
   },
-  "homepage": "https://github.com/worldwonderer/novel-to-game",
-  "repository": "https://github.com/worldwonderer/novel-to-game",
+  "homepage": "https://github.com/zenstory-ai/novel-to-game",
+  "repository": "https://github.com/zenstory-ai/novel-to-game",
   "license": "MIT",
   "keywords": [
     "novel-to-game",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "worldwonderer",
     "url": "https://github.com/worldwonderer"
   },
-  "homepage": "https://github.com/worldwonderer/novel-to-game",
-  "repository": "https://github.com/worldwonderer/novel-to-game",
+  "homepage": "https://github.com/zenstory-ai/novel-to-game",
+  "repository": "https://github.com/zenstory-ai/novel-to-game",
   "license": "MIT",
   "keywords": [
     "novel-to-game",
@@ -32,7 +32,7 @@
     "capabilities": [
       "Write"
     ],
-    "websiteURL": "https://github.com/worldwonderer/novel-to-game",
+    "websiteURL": "https://github.com/zenstory-ai/novel-to-game",
     "defaultPrompt": [
       "Turn this novel into a complete 15-minute game prototype.",
       "Compare three game concepts for this novel before choosing one."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions and early ideas / 问题与早期想法
-    url: https://github.com/worldwonderer/novel-to-game/discussions
+    url: https://github.com/zenstory-ai/novel-to-game/discussions
     about: Ask for help or discuss an idea before it becomes a bounded issue. / 在问题成形前先求助或讨论。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,24 +9,24 @@ All notable changes to NovelToGame are documented here. This project follows
 
 ### Added
 
-- Added a risk-matched whitebox stage and handoff contract between world design and art production, with replayable snapshots, event logs, knowledge boundaries, callbacks, and local patch verification ([#38](https://github.com/worldwonderer/novel-to-game/pull/38)).
-- Added an optional identity-specific `signature_command` contract. Concepts now state the player's job, recurring work loop, resistance chain, and advancement ladder; when adopted, the contract requires finite intents to pass deterministic validation and commit rules instead of granting generated text state authority ([#38](https://github.com/worldwonderer/novel-to-game/pull/38)).
-- Added a lightweight executable-model oracle for the Jin Ping Mei example, covering two distinct openings, three aftermath beats, knowledge provenance, deterministic replay, valid save reconstruction, and branch-pollution rejection ([#38](https://github.com/worldwonderer/novel-to-game/pull/38)).
-- Added the Journey to the West fire-vein treasure route and made tactical choices affect later combat state and outcomes ([#29](https://github.com/worldwonderer/novel-to-game/pull/29), [#36](https://github.com/worldwonderer/novel-to-game/pull/36)).
-- Expanded the adult Jin Ping Mei example into a five-heroine, twenty-day relationship and household-management route with cross-courtyard cooperation, evidence, delayed reckonings, and explicit refusal boundaries ([#30](https://github.com/worldwonderer/novel-to-game/pull/30), [#34](https://github.com/worldwonderer/novel-to-game/pull/34), [#35](https://github.com/worldwonderer/novel-to-game/pull/35)).
-- Added player-led field observation and a field journal to Project Plateau, alongside stronger environment, threat, and evidence feedback ([#31](https://github.com/worldwonderer/novel-to-game/pull/31), [#37](https://github.com/worldwonderer/novel-to-game/pull/37)).
+- Added a risk-matched whitebox stage and handoff contract between world design and art production, with replayable snapshots, event logs, knowledge boundaries, callbacks, and local patch verification ([#38](https://github.com/zenstory-ai/novel-to-game/pull/38)).
+- Added an optional identity-specific `signature_command` contract. Concepts now state the player's job, recurring work loop, resistance chain, and advancement ladder; when adopted, the contract requires finite intents to pass deterministic validation and commit rules instead of granting generated text state authority ([#38](https://github.com/zenstory-ai/novel-to-game/pull/38)).
+- Added a lightweight executable-model oracle for the Jin Ping Mei example, covering two distinct openings, three aftermath beats, knowledge provenance, deterministic replay, valid save reconstruction, and branch-pollution rejection ([#38](https://github.com/zenstory-ai/novel-to-game/pull/38)).
+- Added the Journey to the West fire-vein treasure route and made tactical choices affect later combat state and outcomes ([#29](https://github.com/zenstory-ai/novel-to-game/pull/29), [#36](https://github.com/zenstory-ai/novel-to-game/pull/36)).
+- Expanded the adult Jin Ping Mei example into a five-heroine, twenty-day relationship and household-management route with cross-courtyard cooperation, evidence, delayed reckonings, and explicit refusal boundaries ([#30](https://github.com/zenstory-ai/novel-to-game/pull/30), [#34](https://github.com/zenstory-ai/novel-to-game/pull/34), [#35](https://github.com/zenstory-ai/novel-to-game/pull/35)).
+- Added player-led field observation and a field journal to Project Plateau, alongside stronger environment, threat, and evidence feedback ([#31](https://github.com/zenstory-ai/novel-to-game/pull/31), [#37](https://github.com/zenstory-ai/novel-to-game/pull/37)).
 
 ### Changed
 
-- Made interactive fiction a first-class adaptation track while preserving the same agency and consequence requirements as system-led games ([#19](https://github.com/worldwonderer/novel-to-game/pull/19)).
-- Reduced QA to one evidence-backed path with exactly six player-visible checks; capability-specific regressions stay inside that path instead of creating parallel release gates ([#15](https://github.com/worldwonderer/novel-to-game/pull/15), [#20](https://github.com/worldwonderer/novel-to-game/pull/20)).
-- Slimmed skill entry points, moved conditional depth into one-level references, added size budgets, and split oversized example modules by responsibility ([#27](https://github.com/worldwonderer/novel-to-game/pull/27), [#28](https://github.com/worldwonderer/novel-to-game/pull/28)).
-- Strengthened all three playable examples so choices change concrete state, available actions, evidence, or later outcomes rather than only presentation ([#24](https://github.com/worldwonderer/novel-to-game/pull/24), [#36](https://github.com/worldwonderer/novel-to-game/pull/36), [#37](https://github.com/worldwonderer/novel-to-game/pull/37)).
+- Made interactive fiction a first-class adaptation track while preserving the same agency and consequence requirements as system-led games ([#19](https://github.com/zenstory-ai/novel-to-game/pull/19)).
+- Reduced QA to one evidence-backed path with exactly six player-visible checks; capability-specific regressions stay inside that path instead of creating parallel release gates ([#15](https://github.com/zenstory-ai/novel-to-game/pull/15), [#20](https://github.com/zenstory-ai/novel-to-game/pull/20)).
+- Slimmed skill entry points, moved conditional depth into one-level references, added size budgets, and split oversized example modules by responsibility ([#27](https://github.com/zenstory-ai/novel-to-game/pull/27), [#28](https://github.com/zenstory-ai/novel-to-game/pull/28)).
+- Strengthened all three playable examples so choices change concrete state, available actions, evidence, or later outcomes rather than only presentation ([#24](https://github.com/zenstory-ai/novel-to-game/pull/24), [#36](https://github.com/zenstory-ai/novel-to-game/pull/36), [#37](https://github.com/zenstory-ai/novel-to-game/pull/37)).
 
 ### Fixed
 
-- Fixed Project Plateau exposure settlement and improved route readability without presenting deterministic automation as proof of subjective visual quality ([#32](https://github.com/worldwonderer/novel-to-game/pull/32)).
-- Removed duplicated QA reports, stale evidence surfaces, and redundant generated artifacts while retaining the authoritative runnable evidence path ([#15](https://github.com/worldwonderer/novel-to-game/pull/15), [#25](https://github.com/worldwonderer/novel-to-game/pull/25), [#28](https://github.com/worldwonderer/novel-to-game/pull/28)).
+- Fixed Project Plateau exposure settlement and improved route readability without presenting deterministic automation as proof of subjective visual quality ([#32](https://github.com/zenstory-ai/novel-to-game/pull/32)).
+- Removed duplicated QA reports, stale evidence surfaces, and redundant generated artifacts while retaining the authoritative runnable evidence path ([#15](https://github.com/zenstory-ai/novel-to-game/pull/15), [#25](https://github.com/zenstory-ai/novel-to-game/pull/25), [#28](https://github.com/zenstory-ai/novel-to-game/pull/28)).
 
 ### Validation boundaries
 
@@ -47,7 +47,7 @@ All notable changes to NovelToGame are documented here. This project follows
 - Shipped the first playable Journey to the West and Jin Ping Mei examples.
 - Added native plugin manifests and Agent Skills installation for the supported coding-agent surfaces.
 
-[Unreleased]: https://github.com/worldwonderer/novel-to-game/compare/v0.3.0...HEAD
-[0.3.0]: https://github.com/worldwonderer/novel-to-game/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/worldwonderer/novel-to-game/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/worldwonderer/novel-to-game/releases/tag/v0.1.0
+[Unreleased]: https://github.com/zenstory-ai/novel-to-game/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/zenstory-ai/novel-to-game/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/zenstory-ai/novel-to-game/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/zenstory-ai/novel-to-game/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,10 +20,10 @@ evidence that a generated game actually works.
 - **Pull request:** a bounded change with its own verification and provenance.
 
 Use the structured issue forms instead of a blank issue. Questions and early
-ideas belong in [GitHub Discussions](https://github.com/worldwonderer/novel-to-game/discussions).
+ideas belong in [GitHub Discussions](https://github.com/zenstory-ai/novel-to-game/discussions).
 
 请优先使用 Bug、Skill Gap 或 Example Proposal 表单；尚未成形的问题与想法放到
-[Discussions](https://github.com/worldwonderer/novel-to-game/discussions)。
+[Discussions](https://github.com/zenstory-ai/novel-to-game/discussions)。
 
 ## Before changing files / 修改前
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > Turn a novel in any language into a source-grounded, fully playable game.
 
-[![Validate](https://github.com/worldwonderer/novel-to-game/actions/workflows/validate.yml/badge.svg)](https://github.com/worldwonderer/novel-to-game/actions/workflows/validate.yml) [![Latest release](https://img.shields.io/github/v/release/worldwonderer/novel-to-game?display_name=tag&sort=semver)](https://github.com/worldwonderer/novel-to-game/releases/latest) [![License](https://img.shields.io/github/license/worldwonderer/novel-to-game)](LICENSE) [![GitHub stars](https://img.shields.io/github/stars/worldwonderer/novel-to-game?style=flat&logo=github)](https://github.com/worldwonderer/novel-to-game/stargazers)
+[![Validate](https://github.com/zenstory-ai/novel-to-game/actions/workflows/validate.yml/badge.svg)](https://github.com/zenstory-ai/novel-to-game/actions/workflows/validate.yml) [![Latest release](https://img.shields.io/github/v/release/zenstory-ai/novel-to-game?display_name=tag&sort=semver)](https://github.com/zenstory-ai/novel-to-game/releases/latest) [![License](https://img.shields.io/github/license/zenstory-ai/novel-to-game)](LICENSE) [![GitHub stars](https://img.shields.io/github/stars/zenstory-ai/novel-to-game?style=flat&logo=github)](https://github.com/zenstory-ai/novel-to-game/stargazers)
 
 NovelToGame is an open-source Agent Skills toolkit for Claude Code, Codex, and Kimi Code. It turns novel adaptation into a staged workflow: source analysis, concept selection, world and art direction, implementation, and runtime QA.
 
@@ -42,7 +42,7 @@ Play the full expedition on desktop, or watch the 15-second gameplay preview on 
 
 https://github.com/user-attachments/assets/27819247-4e4d-4bf0-8f0f-43d4125c4d45
 
-**[Play in your browser — no install](https://plateau.vibecoco.ai)** · [Read the case study](examples/project-plateau/) · [Share feedback](https://github.com/worldwonderer/novel-to-game/discussions/7) · 1–3 min run · desktop WebGL2 · playable prototype
+**[Play in your browser — no install](https://plateau.vibecoco.ai)** · [Read the case study](examples/project-plateau/) · [Share feedback](https://github.com/zenstory-ai/novel-to-game/discussions/7) · 1–3 min run · desktop WebGL2 · playable prototype
 
 ## Why NovelToGame
 
@@ -60,14 +60,14 @@ A one-line “turn this book into a game” prompt often produces a generic resk
 
 | Agent CLI | Install | Invoke |
 |---|---|---|
-| Claude Code | `npx skills add worldwonderer/novel-to-game -g -y -a claude-code -s '*'` | `/novel-to-game` |
-| Codex | `npx skills add worldwonderer/novel-to-game -g -y -a codex -s '*'` | `$novel-to-game` |
-| Kimi Code | `npx skills add worldwonderer/novel-to-game -g -y -a kimi-code-cli -s '*'` | `/skill:novel-to-game` |
+| Claude Code | `npx skills add zenstory-ai/novel-to-game -g -y -a claude-code -s '*'` | `/novel-to-game` |
+| Codex | `npx skills add zenstory-ai/novel-to-game -g -y -a codex -s '*'` | `$novel-to-game` |
+| Kimi Code | `npx skills add zenstory-ai/novel-to-game -g -y -a kimi-code-cli -s '*'` | `/skill:novel-to-game` |
 
 Install adapters for all three CLIs on the same machine:
 
 ```bash
-npx skills add worldwonderer/novel-to-game -g -y -s '*' \
+npx skills add zenstory-ai/novel-to-game -g -y -s '*' \
   -a claude-code -a codex -a kimi-code-cli
 ```
 
@@ -104,7 +104,7 @@ press a contradiction, and attitudes that shifted because of what you did earlie
 #### Claude Code
 
 ```text
-/plugin marketplace add worldwonderer/novel-to-game
+/plugin marketplace add zenstory-ai/novel-to-game
 /plugin install novel-to-game@novel-to-game-skills
 /novel-to-game:novel-to-game quick
 ```
@@ -112,14 +112,14 @@ press a contradiction, and attitudes that shifted because of what you did earlie
 #### Codex
 
 ```bash
-codex plugin marketplace add worldwonderer/novel-to-game
+codex plugin marketplace add zenstory-ai/novel-to-game
 codex plugin add novel-to-game@novel-to-game-skills
 ```
 
 #### Kimi Code 0.27 or newer
 
 ```text
-/plugins install https://github.com/worldwonderer/novel-to-game
+/plugins install https://github.com/zenstory-ai/novel-to-game
 /reload
 /skill:novel-to-game quick
 ```

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -2,7 +2,7 @@
 
 > 把任何语言的小说，改编成有原著依据、可完整游玩的游戏。
 
-[![Validate](https://github.com/worldwonderer/novel-to-game/actions/workflows/validate.yml/badge.svg)](https://github.com/worldwonderer/novel-to-game/actions/workflows/validate.yml) [![Latest release](https://img.shields.io/github/v/release/worldwonderer/novel-to-game?display_name=tag&sort=semver)](https://github.com/worldwonderer/novel-to-game/releases/latest) [![License](https://img.shields.io/github/license/worldwonderer/novel-to-game)](LICENSE) [![GitHub stars](https://img.shields.io/github/stars/worldwonderer/novel-to-game?style=flat&logo=github)](https://github.com/worldwonderer/novel-to-game/stargazers)
+[![Validate](https://github.com/zenstory-ai/novel-to-game/actions/workflows/validate.yml/badge.svg)](https://github.com/zenstory-ai/novel-to-game/actions/workflows/validate.yml) [![Latest release](https://img.shields.io/github/v/release/zenstory-ai/novel-to-game?display_name=tag&sort=semver)](https://github.com/zenstory-ai/novel-to-game/releases/latest) [![License](https://img.shields.io/github/license/zenstory-ai/novel-to-game)](LICENSE) [![GitHub stars](https://img.shields.io/github/stars/zenstory-ai/novel-to-game?style=flat&logo=github)](https://github.com/zenstory-ai/novel-to-game/stargazers)
 
 NovelToGame 是一套面向 Claude Code、Codex 和 Kimi Code 的开源 Agent Skills。它把小说游戏化改编拆成一条职责清晰的流程：拆解原著、选择概念、设计世界与美术、完成构建，并在目标运行环境中实际验证。
 
@@ -42,7 +42,7 @@ NovelToGame 是一套面向 Claude Code、Codex 和 Kimi Code 的开源 Agent Sk
 
 https://github.com/user-attachments/assets/27819247-4e4d-4bf0-8f0f-43d4125c4d45
 
-**[浏览器直接试玩，无需安装](https://plateau.vibecoco.ai)** · [查看改编案例](examples/project-plateau/) · [反馈体验](https://github.com/worldwonderer/novel-to-game/discussions/7) · 1–3 分钟一局 · 桌面 WebGL2 · 可玩原型
+**[浏览器直接试玩，无需安装](https://plateau.vibecoco.ai)** · [查看改编案例](examples/project-plateau/) · [反馈体验](https://github.com/zenstory-ai/novel-to-game/discussions/7) · 1–3 分钟一局 · 桌面 WebGL2 · 可玩原型
 
 ## 为什么用 NovelToGame
 
@@ -60,14 +60,14 @@ https://github.com/user-attachments/assets/27819247-4e4d-4bf0-8f0f-43d4125c4d45
 
 | Agent CLI | 安装命令 | 调用方式 |
 |---|---|---|
-| Claude Code | `npx skills add worldwonderer/novel-to-game -g -y -a claude-code -s '*'` | `/novel-to-game` |
-| Codex | `npx skills add worldwonderer/novel-to-game -g -y -a codex -s '*'` | `$novel-to-game` |
-| Kimi Code | `npx skills add worldwonderer/novel-to-game -g -y -a kimi-code-cli -s '*'` | `/skill:novel-to-game` |
+| Claude Code | `npx skills add zenstory-ai/novel-to-game -g -y -a claude-code -s '*'` | `/novel-to-game` |
+| Codex | `npx skills add zenstory-ai/novel-to-game -g -y -a codex -s '*'` | `$novel-to-game` |
+| Kimi Code | `npx skills add zenstory-ai/novel-to-game -g -y -a kimi-code-cli -s '*'` | `/skill:novel-to-game` |
 
 在同一台机器上为三个 CLI 安装适配器：
 
 ```bash
-npx skills add worldwonderer/novel-to-game -g -y -s '*' \
+npx skills add zenstory-ai/novel-to-game -g -y -s '*' \
   -a claude-code -a codex -a kimi-code-cli
 ```
 
@@ -102,7 +102,7 @@ npx skills add worldwonderer/novel-to-game -g -y -s '*' \
 #### Claude Code
 
 ```text
-/plugin marketplace add worldwonderer/novel-to-game
+/plugin marketplace add zenstory-ai/novel-to-game
 /plugin install novel-to-game@novel-to-game-skills
 /novel-to-game:novel-to-game quick
 ```
@@ -110,14 +110,14 @@ npx skills add worldwonderer/novel-to-game -g -y -s '*' \
 #### Codex
 
 ```bash
-codex plugin marketplace add worldwonderer/novel-to-game
+codex plugin marketplace add zenstory-ai/novel-to-game
 codex plugin add novel-to-game@novel-to-game-skills
 ```
 
 #### Kimi Code 0.27 或更高版本
 
 ```text
-/plugins install https://github.com/worldwonderer/novel-to-game
+/plugins install https://github.com/zenstory-ai/novel-to-game
 /reload
 /skill:novel-to-game quick
 ```


### PR DESCRIPTION
## Summary
- update the canonical repository namespace from `worldwonderer/novel-to-game` to `zenstory-ai/novel-to-game`
- update install commands, badges, Discussions/issue links, release history links, and plugin repository metadata
- set the Claude marketplace publisher owner to `zenstory-ai` while preserving personal author/developer attribution to `worldwonderer`

## Verification
- `python3 scripts/validate_repo.py`
- `python3 -m unittest discover -s tests -v` (47 tests)
- `npm test` in `examples/journey-to-the-west/build/app` (245 + 12 checks; design contract 8 groups)
- `npm ci && npm test && npm run build` in `examples/project-plateau/build/app` (201 tests; Vite build)

No game source paths changed, so the production deploy workflow is intentionally not triggered. No Vercel relink or production deployment is part of this PR.
