### PR TITLE
fix: deploy Vercel projects from repository root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches: [main]
     paths:
+      - '.github/workflows/deploy.yml'
       - 'examples/jin-ping-mei/build/app/**'
       - 'examples/journey-to-the-west/build/app/**'
       - 'examples/project-plateau/build/app/**'
@@ -34,10 +35,13 @@ jobs:
         with:
           filters: |
             jpm:
+              - '.github/workflows/deploy.yml'
               - 'examples/jin-ping-mei/build/app/**'
             jttw:
+              - '.github/workflows/deploy.yml'
               - 'examples/journey-to-the-west/build/app/**'
             plateau:
+              - '.github/workflows/deploy.yml'
               - 'examples/project-plateau/build/app/**'
 
   jinpingmei:
@@ -51,7 +55,8 @@ jobs:
       - uses: actions/checkout@v7
       - run: npm i -g vercel@56.4.0
       - name: Deploy jinpingmei to production
-        working-directory: examples/jin-ping-mei/build/app
+        # The Vercel project already owns its Root Directory. Running from that
+        # directory here would make the CLI append the same path a second time.
         run: vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}"
 
   xiyouji:
@@ -65,7 +70,6 @@ jobs:
       - uses: actions/checkout@v7
       - run: npm i -g vercel@56.4.0
       - name: Deploy xiyouji to production
-        working-directory: examples/journey-to-the-west/build/app
         run: vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}"
 
   project-plateau:
@@ -79,5 +83,4 @@ jobs:
       - uses: actions/checkout@v7
       - run: npm i -g vercel@56.4.0
       - name: Deploy Project Plateau to production
-        working-directory: examples/project-plateau/build/app
         run: vercel deploy --prod --yes --token="${{ secrets.VERCEL_TOKEN }}"

--- a/tests/test_validate_repo.py
+++ b/tests/test_validate_repo.py
@@ -350,6 +350,17 @@ class RepositoryValidationTests(unittest.TestCase):
     def test_repository_contract_is_valid(self) -> None:
         self.assertEqual(validate_repository(ROOT), [])
 
+    def test_vercel_deploy_uses_project_root_directories_once(self) -> None:
+        workflow = (ROOT / ".github/workflows/deploy.yml").read_text(encoding="utf-8")
+        self.assertNotIn("working-directory:", workflow)
+        for app_path in (
+            "examples/jin-ping-mei/build/app/**",
+            "examples/journey-to-the-west/build/app/**",
+            "examples/project-plateau/build/app/**",
+        ):
+            self.assertIn(app_path, workflow)
+        self.assertEqual(4, workflow.count("'.github/workflows/deploy.yml'"))
+
     def test_skill_validator_rejects_todo_and_broken_link(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             skill = Path(temporary) / "demo"


### PR DESCRIPTION
## Summary

- run Vercel CLI from the repository root so each project Root Directory is applied exactly once
- make deploy workflow changes trigger all three production projects, allowing deployment fixes to verify themselves immediately
- add a regression test that rejects per-job working directories and requires the workflow self-trigger paths

## Root cause

The Vercel projects now define their own Root Directory. The workflow also changed into the same app directory before invoking Vercel, so the CLI resolved paths such as examples/jin-ping-mei/build/app/examples/jin-ping-mei/build/app and failed before upload.

## Verification

- repository validator passed
- 48 unit tests passed
- deploy.yml parsed successfully as YAML
- git diff --check passed
