### PR TITLE
docs(changelog): reference Keep a Changelog and state the section rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
-All notable changes to NovelToGame are documented here. This project follows
-[Semantic Versioning](https://semver.org/spec/v2.0.0.html); release dates use YYYY-MM-DD.
+All notable changes to NovelToGame are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html);
+release dates use YYYY-MM-DD.
+
+Sections use the six Keep a Changelog categories. A change that starts refusing
+input which previously passed belongs under `Changed`, not `Fixed`.
 
 ## [Unreleased]
 


### PR DESCRIPTION
Adopts the organization standard from [the `release-writing` skill](https://github.com/zenstory-ai/.github/tree/main/skills/release-writing).

This repository was already the closest to the standard in the org — English category names, bracketed version headings, and compare link references were all present.

Two header additions:

- Name **Keep a Changelog** alongside Semantic Versioning, since that is where the six category names come from.
- State the one classification call that is easy to get wrong: a change that starts refusing input which previously passed belongs under `Changed`, not `Fixed`. Getting this backwards lets a reader treat a breaking release as safe.

No existing entries are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)